### PR TITLE
Fix "exclude_from_bom" component property

### DIFF
--- a/kinparse/kinparse.py
+++ b/kinparse/kinparse.py
@@ -94,7 +94,7 @@ def _parse_netlist_kicad(text):
     datasheet = _paren_clause('datasheet', anystring('datasheet'))
     field = Group(_paren_clause('field', name & anystring('value')))
     fields = _paren_clause('fields', ZeroOrMore(field)('fields'))
-    property = Group(_paren_clause('property', name & value))
+    property = Group(_paren_clause('property', name & Optional(value)))
     properties = OneOrMore(property)('properties')
     lib = _paren_clause('lib', anystring('lib'))
     part = _paren_clause('part', anystring('name'))

--- a/tests/data/kicad6_test.net
+++ b/tests/data/kicad6_test.net
@@ -34,6 +34,7 @@
       (libsource (lib "Device") (part "R_US") (description "Resistor, US symbol"))
       (property (name "Sheetname") (value ""))
       (property (name "Sheetfile") (value "kicad6_test_2.kicad_sch"))
+      (property (name "exclude_from_bom"))
       (sheetpath (names "/") (tstamps "/"))
       (tstamps "0520cef8-5eb4-4ad6-9db3-e738a3afea43"))
     (comp (ref "R2")


### PR DESCRIPTION
The "exclude_from_bom" component property is standalone and does not have a value associated to it. The current implementation of kinparse assumes that a value is always associated to a property name. This commit fixes it. The property has also been added in the kicad_6 netlist to test the fix.